### PR TITLE
Update building and testing scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,80 +1,121 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 # project name
 project(ProbReach)
 
+# setting path to additional cmake modules 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
-
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 
-# checking for packages
-find_package(CAPD)
-find_package(BISON REQUIRED)
-find_package(FLEX REQUIRED)
-find_package(GSL)
-find_package(GTest)
-# Needed for using the translator tool
-#find_package(Matlab)
-
-# setting compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11 -fopenmp -frounding-math -fPIC")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-unused-variable -Wno-return-type -Wno-unused-function")
-#set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
-
-# setting some environment variables
+# setting install/build/test paths, etc.
 set(PROBREACH_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src)
 set(PROBREACH_BINARY_DIR ${CMAKE_BINARY_DIR})
 set(PROBREACH_TEST_DIR ${CMAKE_SOURCE_DIR}/test)
-
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# setting ProbReach version
+# setting version related variables (i.e., MAJOR, MINOR and GIT_SHA1)
 set(PROBREACH_VERSION_MAJOR 1)
 set(PROBREACH_VERSION_MINOR 4)
-
-# getting git commit as a string
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 configure_file(
-        "${PROBREACH_SOURCE_DIR}/util/git_sha1.cpp.in"
-        "${PROBREACH_BINARY_DIR}/git_sha1.cpp" @ONLY)
+  "${PROBREACH_SOURCE_DIR}/util/git_sha1.cpp.in"
+  "${PROBREACH_BINARY_DIR}/git_sha1.cpp" @ONLY)
+set_source_files_properties(${PROBREACH_BINARY_DIR}/git_sha1.cpp GENERATED PROPERTIES LANGUAGE CXX)
+set(PROBREACH_VERSION ${PROBREACH_VERSION_MAJOR}.${PROBREACH_VERSION_MINOR})
+configure_file(
+  "${PROBREACH_SOURCE_DIR}/version.h.in"
+  "${PROBREACH_SOURCE_DIR}/version.h")
+
+# setting compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++14 -fopenmp -frounding-math -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-unused-variable -Wno-return-type -Wno-unused-function")
+#set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+
+
+# building and installing PDRH lexer and parser
+find_package(BISON REQUIRED)
+find_package(FLEX REQUIRED)
 
 # creating a directory for the lexer and parser files
 add_custom_target(pdrhparser
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${PROBREACH_BINARY_DIR}/parser/pdrh
-        COMMENT "Creating directory ${PROBREACH_BINARY_DIR}/parser/pdrh")
-
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${PROBREACH_BINARY_DIR}/parser/pdrh
+  COMMENT "Creating directory ${PROBREACH_BINARY_DIR}/parser/pdrh")
 # create custom command for flex/lex (note the outputs)
 add_custom_command(
-        COMMAND ${FLEX_EXECUTABLE}
-        ARGS -o ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c
-        ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhlexer.l
-        DEPENDS pdrhparser
-        DEPENDS ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhlexer.l
-        OUTPUT  ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c
-        COMMENT "Generating ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c")
+  COMMAND ${FLEX_EXECUTABLE}
+  ARGS -o ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c
+  ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhlexer.l
+  DEPENDS pdrhparser
+  DEPENDS ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhlexer.l
+  OUTPUT  ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c
+  COMMENT "Generating ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c")
 
 # create custom command for bison/yacc (note the DEPENDS)
 add_custom_command(
-        COMMAND ${BISON_EXECUTABLE}
-        ARGS -d -y ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhparser.y
-        -o ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c
-        DEPENDS ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c
-        DEPENDS ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhparser.y
-        OUTPUT  ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c
-        COMMENT "Generating ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c")
+  COMMAND ${BISON_EXECUTABLE}
+  ARGS -d -y ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhparser.y
+  -o ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c
+  DEPENDS ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c
+  DEPENDS ${PROBREACH_SOURCE_DIR}/parser/pdrh/pdrhparser.y
+  OUTPUT  ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c
+  COMMENT "Generating ${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c")
 
 # setting propeties for the generated lexer and parser files
 set_source_files_properties(${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhparser.c GENERATED PROPERTIES LANGUAGE CXX)
 set_source_files_properties(${PROBREACH_BINARY_DIR}/parser/pdrh/pdrhlexer.c GENERATED PROPERTIES LANGUAGE CXX)
-set_source_files_properties(${PROBREACH_BINARY_DIR}/git_sha1.cpp GENERATED PROPERTIES LANGUAGE CXX)
+# including the parser directory
+include_directories("${PROBREACH_BINARY_DIR}/parser/pdrh")
 
-set(PROBREACH_VERSION ${PROBREACH_VERSION_MAJOR}.${PROBREACH_VERSION_MINOR})
-configure_file(
-        "${PROBREACH_SOURCE_DIR}/version.h.in"
-        "${PROBREACH_SOURCE_DIR}/version.h")
+# building and installing CAPD
+set(CAPD_BUILD_PATH ${PROBREACH_BINARY_DIR}/external CACHE INTERNAL "")
+set(CAPD_INSTALL_PATH ${PROBREACH_BINARY_DIR} CACHE INTERNAL "")
+find_package(CAPD)
+IF(CAPD_FOUND)
+  message(STATUS "Found CAPD (headers: ${CAPD_INCLUDE_DIR}; libs: ${CAPD_LIBRARIES})")
+  add_custom_target(capd)
+ELSE(CAPD_FOUND)
+  set(CAPD_URL "https://sourceforge.net/projects/capd/files/5.1.2/src/capd-capdDynSys-5.1.2.tar.gz")
+  message(STATUS "CAPD not found at ${CAPD_INSTALL_PATH}")
+  message(STATUS ">>> CAPD version from ${CAPD_URL} will be automatically installed to ${CAPD_INSTALL_PATH}")
+  message(STATUS ">>> If you want to specify a different location, please specify the following variables:")
+  message(STATUS ">>>   CAPD_BUILD_PATH - path where CAPD will be built")
+  message(STATUS ">>>   CAPD_INSTALL_PATH - path where CAPD headers and libraries will be installed")
+  message(STATUS "")
+  message(STATUS ">>> If you have a version of CAPD already installed on your system, please set the following variables:")
+  message(STATUS ">>>   CAPD_INCLUDE_DIR - path to CAPD headers")
+  message(STATUS ">>>   CAPD_LIBRARIES - path to \"libcapd.a\"")
+  message(STATUS "")
+  ExternalProject_Add(capd
+    PREFIX ${CAPD_BUILD_PATH}
+    URL ${CAPD_URL}
+    UPDATE_COMMAND ""
+    CONFIGURE_COMMAND ${CAPD_BUILD_PATH}/src/capd/configure
+      C=${CMAKE_C_COMPILER}
+      XX=${CMAKE_CXX_COMPILER}
+      --prefix=${CAPD_INSTALL_PATH}
+      --without-gui
+	    --with-mpfr=no
+      --with-filib=no
+    BUILD_COMMAND make
+    BUILD_IN_SOURCE 1
+    LOG_DOWNLOAD 1
+    LOG_UPDATE 1
+    LOG_CONFIGURE 1
+    LOG_BUILD 1
+    LOG_TEST 1
+    LOG_INSTALL 1
+    INSTALL_COMMAND make install)
+	
+  set(CAPD_INCLUDE_DIR "${CAPD_INSTALL_PATH}/include")
+  set(CAPD_LIBRARIES "${CAPD_INSTALL_PATH}/lib/libcapd.a")
+	set(CAPD_FOUND ON)
+ENDIF(CAPD_FOUND)
+# including CAPD headers
+include_directories("${CAPD_INCLUDE_DIR}")
 
+# including all the ProbReach headers
 include_directories("${PROBREACH_SOURCE_DIR}")
 include_directories("${PROBREACH_SOURCE_DIR}/util")
 include_directories("${PROBREACH_SOURCE_DIR}/util/generators")
@@ -84,39 +125,14 @@ include_directories("${PROBREACH_SOURCE_DIR}/parser/output")
 include_directories("${PROBREACH_SOURCE_DIR}/parser/pdrh")
 include_directories("${PROBREACH_SOURCE_DIR}/solver")
 include_directories("${PROBREACH_SOURCE_DIR}/logging")
-include_directories("${PROBREACH_BINARY_DIR}/parser/pdrh")
-include_directories("${GSL_INCLUDE_DIRS}")
 
-IF(NOT CAPD_FOUND)
-	ExternalProject_Add(capd
-	PREFIX ${PROBREACH_BINARY_DIR}/external
-      	URL https://sourceforge.net/projects/capd/files/5.1.2/src/capd-capdDynSys-5.1.2.tar.gz
-      	UPDATE_COMMAND ""
-      	CONFIGURE_COMMAND ${PROBREACH_BINARY_DIR}/external/src/capd/configure
-        	C=${CMAKE_C_COMPILER}
-          	XX=${CMAKE_CXX_COMPILER}
-          	--prefix=${PROBREACH_BINARY_DIR}
-          	--without-gui
-	        --with-mpfr=no
-          	--with-filib=no
-      	BUILD_COMMAND make
-      	BUILD_IN_SOURCE 1
-      	LOG_DOWNLOAD 1
-      	LOG_UPDATE 1
-      	LOG_CONFIGURE 1
-      	LOG_BUILD 1
-      	LOG_TEST 1
-      	LOG_INSTALL 1
-      	INSTALL_COMMAND make install)
-	
-	set(CAPD_INCLUDE_DIR "${PROBREACH_BINARY_DIR}/include")
-	set(CAPD_LIBRARIES "${PROBREACH_BINARY_DIR}/lib/libcapd.a")
-	set(CAPD_FOUND ON)
-ENDIF(NOT CAPD_FOUND)
+# searching for GSL
+find_package(GSL)
+if(GSL_FOUND)
+  include_directories("${GSL_INCLUDE_DIRS}")
+endif(GSL_FOUND)
 
-include_directories("${CAPD_INCLUDE_DIR}")
-
-# Adds the option to build the translator if MATLAB is located
+# adding CMakeLists.txt files that specify executables
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/simulator/CMakeLists.txt)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/pid_optimiser/CMakeLists.txt)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/formal_verifier/CMakeLists.txt)
@@ -124,6 +140,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/src/mc_verifier/CMakeLists.txt)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/qmc_verifier/CMakeLists.txt)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/gp/CMakeLists.txt)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/translator/CMakeLists.txt)
-include(${CMAKE_CURRENT_SOURCE_DIR}/test/util/CMakeLists.txt)
 
-
+# enabling testing
+find_package(GTest)
+if(GTest_FOUND)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/test/util/CMakeLists.txt)
+endif(GTest_FOUND)

--- a/README.md
+++ b/README.md
@@ -20,3 +20,24 @@ make
 * [**pid_optimiser**](doc/pid_optimiser/README.md) - performs controller synthesis for sampled-data stochastic control systems.
 * [**gp**](doc/gp/README.md) - estimates bounded reachability probability function via Gaussian process.
 * [**pdrh2simulink**](doc/pdrh2simulink/README.md) - translates the provided ProbReach model into *Simulink®/Stateflow®* format.
+
+
+## How to run tests
+ProbReach uses [GoogleTest](https://github.com/google/googletest) for testing. Here is how you can set it up (click [here](https://github.com/google/googletest/blob/main/googletest/README.md) for more detailed instructions):
+```
+git clone https://github.com/google/googletest.git -b v1.15.2
+cd googletest
+mkdir build
+cd build
+cmake ../
+make
+sudo make install
+```
+
+Once GoogleTest is built and installed on your system, here is how you can use it to run ProbReach tests:
+```
+cd probreach/build/release
+cmake ../../
+make
+make test
+```

--- a/cmake/Modules/FindCAPD.cmake
+++ b/cmake/Modules/FindCAPD.cmake
@@ -1,44 +1,26 @@
-# - Finding CAPD library
-#  CAPD_FOUND - CAPD is found
-#  CAPD_INCLUDE_DIR - CAPD include directories
-#  CAPD_LIBRARIES - CAPD library
-
-set(CAPD_INCLUDE_DIR_LIST ${CAPD_INCLUDE_DIR_LIST} /usr/capd/include)
-set(CAPD_INCLUDE_DIR_LIST ${CAPD_INCLUDE_DIR_LIST} /usr/local/capd/include)
-
-#set(CAPD_LIBRARIES_LIST ${CAPD_LIBRARIES_LIST} /usr/capd/lib/libcapd-gui.a)
-#set(CAPD_LIBRARIES_LIST ${CAPD_LIBRARIES_LIST} /usr/local/capd/lib/libcapd-gui.a)
-
-set(CAPD_LIBRARIES_LIST ${CAPD_LIBRARIES_LIST} /usr/capd/lib/libcapd.a)
-set(CAPD_LIBRARIES_LIST ${CAPD_LIBRARIES_LIST} /usr/local/capd/lib/libcapd.a)
+# - Finding CAPD library. Variable that will be set if CAPD is found:
+#
+#       CAPD_FOUND - CAPD is found
+#       CAPD_INCLUDE_DIR - CAPD include directories
+#       CAPD_LIBRARIES - CAPD library
 
 if(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
-    set(CAPD_FOUND TRUE)
+  set(CAPD_FOUND ON)
 else(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
 
-    # finding include directories
-    foreach(ITEM ${CAPD_INCLUDE_DIR_LIST})
-        if(EXISTS ${ITEM} AND NOT CAPD_INCLUDE_DIR)
-            set(CAPD_INCLUDE_DIR ${ITEM})
-        endif(EXISTS ${ITEM} AND NOT CAPD_INCLUDE_DIR)
-    endforeach(ITEM)
+  # searching for includes
+  if(EXISTS ${CAPD_INSTALL_PATH}/include/capd)
+    set(CAPD_INCLUDE_DIR "${CAPD_INSTALL_PATH}/include")
+  endif(EXISTS ${CAPD_INSTALL_PATH}/include/capd)
 
-    # finding libraries
-    foreach(ITEM ${CAPD_LIBRARIES_LIST})
-        if(EXISTS ${ITEM} AND NOT CAPD_LIBRARIES)
-            set(CAPD_LIBRARIES ${ITEM})
-        endif(EXISTS ${ITEM} AND NOT CAPD_LIBRARIES)
-    endforeach(ITEM)
+  # searching for libraries
+  if(EXISTS ${CAPD_INSTALL_PATH}/lib/libcapd.a)
+    set(CAPD_LIBRARIES "${CAPD_INSTALL_PATH}/lib/libcapd.a")
+  endif(EXISTS ${CAPD_INSTALL_PATH}/lib/libcapd.a)
 
-    # checking if include directories and libraries has been found
-    if(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
-        set(CAPD_FOUND TRUE)
-    endif(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
+  # checking if include directories and libraries has been found
+  if(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
+    set(CAPD_FOUND ON)
+  endif(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
+
 endif(CAPD_INCLUDE_DIR AND CAPD_LIBRARIES)
-
-# reporting whether CAPD has been found
-if(CAPD_FOUND)
-    message(STATUS "Found CAPD (includes: ${CAPD_INCLUDE_DIR}, libs: ${CAPD_LIBRARIES})")
-else(CAPD_FOUND)
-    message(STATUS "CAPD not found")
-endif(CAPD_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+include("${PROBREACH_TEST_DIR}/util")

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,25 +1,24 @@
-if(GTEST_FOUND)
-    # Building tests
-    enable_testing()
+# Building tests
+enable_testing()
 
-    include_directories("${PROBREACH_SOURCE_DIR}/util")
+include_directories("${PROBREACH_SOURCE_DIR}/util")
 
-    # setting the output directory for ProbReach
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROBREACH_BINARY_DIR}/test)
+# setting the output directory for ProbReach
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROBREACH_BINARY_DIR}/test)
 
-    # unit test for box.cpp
-    add_executable(box_test ${PROBREACH_TEST_DIR}/util/box_test.cpp
-            ${PROBREACH_TEST_DIR}/main_test.cpp
-            ${PROBREACH_SOURCE_DIR}/util/box.cpp)
-    target_link_libraries(box_test ${CAPD_LIBRARIES} -lgtest)
-    add_test(box_test ${PROBREACH_BINARY_DIR}/test/util/box_test)
+# unit test for box.cpp
+add_executable(box_test ${PROBREACH_TEST_DIR}/util/box_test.cpp
+        ${PROBREACH_TEST_DIR}/main_test.cpp
+        ${PROBREACH_SOURCE_DIR}/util/box.cpp)
+target_link_libraries(box_test ${CAPD_LIBRARIES} -lgtest)
+add_test(box_test ${PROBREACH_BINARY_DIR}/test/util/box_test)
 
-    # unit test for the methods in node.cpp
-    add_executable(node_test ${PROBREACH_TEST_DIR}/util/node_test.cpp
-            ${PROBREACH_TEST_DIR}/main_test.cpp
-            ${PROBREACH_SOURCE_DIR}/util/node.cpp)
-    target_link_libraries(node_test -lgtest)
-    add_test(node_test ${PROBREACH_BINARY_DIR}/test/util/node_test)
+# unit test for the methods in node.cpp
+add_executable(node_test ${PROBREACH_TEST_DIR}/util/node_test.cpp
+        ${PROBREACH_TEST_DIR}/main_test.cpp
+        ${PROBREACH_SOURCE_DIR}/util/node.cpp)
+target_link_libraries(node_test -lgtest)
+add_test(node_test ${PROBREACH_BINARY_DIR}/test/util/node_test)
 
 #    # unit test for the methods in naive.cpp
 #    add_executable(naive_test ${PROBREACH_TEST_DIR}/util/naive_test.cpp
@@ -72,5 +71,3 @@ if(GTEST_FOUND)
 #            ${PROBREACH_SOURCE_DIR}/solver/dreal_wrapper.cpp)
 #    target_link_libraries(solver_wrapper_test ${DREAL_LIBRARIES} -lgtest -lfl pdrh2smt)
 #    add_test(solver_wrapper_test ${PROBREACH_BINARY_DIR}/test/solver_wrapper_test)
-
-endif(GTEST_FOUND)

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,73 +1,20 @@
-# Building tests
 enable_testing()
 
 include_directories("${PROBREACH_SOURCE_DIR}/util")
 
 # setting the output directory for ProbReach
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROBREACH_BINARY_DIR}/test)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROBREACH_BINARY_DIR}/test/util")
 
 # unit test for box.cpp
 add_executable(box_test ${PROBREACH_TEST_DIR}/util/box_test.cpp
         ${PROBREACH_TEST_DIR}/main_test.cpp
         ${PROBREACH_SOURCE_DIR}/util/box.cpp)
 target_link_libraries(box_test ${CAPD_LIBRARIES} -lgtest)
-add_test(box_test ${PROBREACH_BINARY_DIR}/test/util/box_test)
+add_test(box_test "${PROBREACH_BINARY_DIR}/test/util/box_test")
 
 # unit test for the methods in node.cpp
 add_executable(node_test ${PROBREACH_TEST_DIR}/util/node_test.cpp
         ${PROBREACH_TEST_DIR}/main_test.cpp
         ${PROBREACH_SOURCE_DIR}/util/node.cpp)
 target_link_libraries(node_test -lgtest)
-add_test(node_test ${PROBREACH_BINARY_DIR}/test/util/node_test)
-
-#    # unit test for the methods in naive.cpp
-#    add_executable(naive_test ${PROBREACH_TEST_DIR}/util/naive_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp
-#            ${PROBREACH_SOURCE_DIR}/util/node.cpp
-#            ${PROBREACH_SOURCE_DIR}/util/naive.cpp)
-#    target_link_libraries(naive_test -lgtest)
-#    add_test(naive_test ${PROBREACH_BINARY_DIR}/test/util/naive_test)
-
-    # unit test for stability.cpp
-#    add_executable(stability_test ${PROBREACH_TEST_DIR}/util/stability_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp
-#            ${PROBREACH_SOURCE_DIR}/util/stability.cpp)
-#    target_link_libraries(stability_test ${DREAL_LIBRARIES} -lgtest)
-#    add_test(stability_test ${PROBREACH_BINARY_DIR}/test/stability_test)
-
-    # unit test for box_factory.cpp
-#    add_executable(box_factory_test ${PROBREACH_TEST_DIR}/util/box_factory_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp
-#            ${PROBREACH_SOURCE_DIR}/util/box.cpp
-#            ${PROBREACH_SOURCE_DIR}/util/box_factory.cpp)
-#    target_link_libraries(box_test ${DREAL_LIBRARIES} -lgtest)
-#    add_test(box_factory_test ${PROBREACH_BINARY_DIR}/test/box_factory_test)
-
-#    # unit test for node.cpp
-#    add_executable(node_test ${PROBREACH_TEST_DIR}/pdrh2smt/node_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp
-#            ${PROBREACH_SOURCE_DIR}/pdrh2smt/node.cpp)
-#    target_link_libraries(node_test ${DREAL_LIBRARIES} -lgtest)
-#    add_test(node_test ${PROBREACH_BINARY_DIR}/test/node_test)
-#
-#    # unit test for pdrhparser.cpp
-#    add_executable(pdrhparser_test ${PROBREACH_TEST_DIR}/pdrh2smt/parser/pdrhparser_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp)
-#    target_link_libraries(pdrhparser_test ${DREAL_LIBRARIES} -lgtest -lfl pdrh2smt)
-#    add_test(pdrhparser_test ${PROBREACH_BINARY_DIR}/test/pdrhparser_test)
-#
-#    # unit test for isat_generator.cpp
-#    add_executable(isat_generator_test ${PROBREACH_TEST_DIR}/pdrh2smt/isat_generator_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp
-#            ${PROBREACH_SOURCE_DIR}/pdrh2smt/isat_generator.cpp)
-#    target_link_libraries(isat_generator_test ${DREAL_LIBRARIES} -lgtest -lfl pdrh2smt)
-#    add_test(isat_generator_test ${PROBREACH_BINARY_DIR}/test/isat_generator_test)
-
-    # unit test for solver_wrapper.cpp
-#    add_executable(solver_wrapper_test ${PROBREACH_TEST_DIR}/solver/solver_wrapper_test.cpp
-#            ${PROBREACH_TEST_DIR}/main_test.cpp
-#            ${PROBREACH_SOURCE_DIR}/solver/solver_wrapper.cpp
-#            ${PROBREACH_SOURCE_DIR}/solver/isat_wrapper.cpp
-#            ${PROBREACH_SOURCE_DIR}/solver/dreal_wrapper.cpp)
-#    target_link_libraries(solver_wrapper_test ${DREAL_LIBRARIES} -lgtest -lfl pdrh2smt)
-#    add_test(solver_wrapper_test ${PROBREACH_BINARY_DIR}/test/solver_wrapper_test)
+add_test(node_test "${PROBREACH_BINARY_DIR}/test/util/node_test")


### PR DESCRIPTION
This PR make the following updates:
- Minimum required version of CMake was upgraded from 2.6 to 3.10
- CAPD is now not re-built every time `cmake` is run.
- GoogleTest was enabled, and C++ standard was upgraded from 11 to 14 as the result.
- Instructions on how to run ProbReach tests are added to README